### PR TITLE
(api) (wpf) Add SetCurrent<T> extension method

### DIFF
--- a/src/Typed.Xaml.Wpf/DependencyObjectExtensions.cs
+++ b/src/Typed.Xaml.Wpf/DependencyObjectExtensions.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace Typed.Xaml
+{
+    public static partial class DependencyObjectExtensions
+    {
+        public static void SetCurrent<T>(this DependencyObject obj, DependencyProperty property, T value)
+        {
+            obj.SetCurrentValue(property, value);
+        }
+    }
+}

--- a/src/Typed.Xaml.Wpf/Typed.Xaml.Wpf.csproj
+++ b/src/Typed.Xaml.Wpf/Typed.Xaml.Wpf.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <Compile Include="AnimatableExtensions.cs" />
     <Compile Include="Converters\ConverterBase.cs" />
+    <Compile Include="DependencyObjectExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Although this doesn't provide much practical value (I won't lie), I figured it would be best to include this for symmetry, since we have a `Set<T>()` extension method that does essentially the same thing.