### PR TITLE
(wip) (wpf) Add AddOwner<T> API for DependencyProperty

### DIFF
--- a/src/Typed.Xaml.Wpf/DependencyPropertyExtensions.cs
+++ b/src/Typed.Xaml.Wpf/DependencyPropertyExtensions.cs
@@ -6,16 +6,16 @@ namespace Typed.Xaml
 {
     public static class DependencyPropertyExtensions
     {
-        public static DependencyProperty AddOwner<T>(this DependencyProperty property)
-            where T : DependencyObject
+        public static DependencyProperty AddOwner<TOwner>(this DependencyProperty property)
+            where TOwner : DependencyObject
         {
-            return property.AddOwner(typeof(T));
+            return property.AddOwner(typeof(TOwner));
         }
         
-        public static DependencyProperty AddOwner<T>(this DependencyProperty property, PropertyMetadata metadata)
-            where T : DependencyObject
+        public static DependencyProperty AddOwner<TOwner>(this DependencyProperty property, PropertyMetadata metadata)
+            where TOwner : DependencyObject
         {
-            return property.AddOwner(typeof(T), metadata);
+            return property.AddOwner(typeof(TOwner), metadata);
         }
     }
 }

--- a/src/Typed.Xaml.Wpf/DependencyPropertyExtensions.cs
+++ b/src/Typed.Xaml.Wpf/DependencyPropertyExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace Typed.Xaml
+{
+    public static class DependencyPropertyExtensions
+    {
+        public static DependencyProperty AddOwner<T>(this DependencyProperty property)
+            where T : DependencyObject
+        {
+            return property.AddOwner(typeof(T));
+        }
+        
+        public static DependencyProperty AddOwner<T>(this DependencyProperty property, PropertyMetadata metadata)
+            where T : DependencyObject
+        {
+            return property.AddOwner(typeof(T), metadata);
+        }
+    }
+}

--- a/src/Typed.Xaml.Wpf/Typed.Xaml.Wpf.csproj
+++ b/src/Typed.Xaml.Wpf/Typed.Xaml.Wpf.csproj
@@ -43,6 +43,7 @@
     <Compile Include="AnimatableExtensions.cs" />
     <Compile Include="Converters\ConverterBase.cs" />
     <Compile Include="DependencyObjectExtensions.cs" />
+    <Compile Include="DependencyPropertyExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Typed.Xaml/Dependency.cs
+++ b/src/Typed.Xaml/Dependency.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Data;
+using Typed.Xaml.Internal;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 
@@ -9,16 +10,10 @@ namespace Typed.Xaml
 {
     public static class Dependency
     {
-        private static PropertyMetadata CreateMetadata<T, TOwner>(PropertyChangedCallback<T, TOwner> callback)
-            where TOwner : DependencyObject
-        {
-            return new PropertyMetadata(default(T), WrapGenericCallback(callback));
-        }
-
         public static DependencyProperty Register<T, TOwner>(string name, PropertyChangedCallback<T, TOwner> callback)
             where TOwner : DependencyObject
         {
-            return Register<T, TOwner>(name, CreateMetadata(callback));
+            return Register<T, TOwner>(name, Metadata.CreateFrom(callback));
         }
 
         public static DependencyProperty Register<T, TOwner>(string name, PropertyMetadata metadata)
@@ -30,18 +25,12 @@ namespace Typed.Xaml
         public static DependencyProperty RegisterAttached<T, TOwner, TDeclaring>(string name, PropertyChangedCallback<T, TOwner> callback)
             where TOwner : DependencyObject
         {
-            return RegisterAttached<T, TDeclaring>(name, CreateMetadata(callback));
+            return RegisterAttached<T, TDeclaring>(name, Metadata.CreateFrom(callback));
         }
 
         public static DependencyProperty RegisterAttached<T, TDeclaring>(string name, PropertyMetadata metadata)
         {
             return DependencyProperty.RegisterAttached(name, typeof(T), typeof(TDeclaring), metadata);
-        }
-
-        private static PropertyChangedCallback WrapGenericCallback<T, TOwner>(PropertyChangedCallback<T, TOwner> original)
-            where TOwner : DependencyObject
-        {
-            return (o, args) => original((TOwner)o, PropertyChangedArgs<T>.CreateFrom(args));
         }
     }
 }

--- a/src/Typed.Xaml/Internal/Metadata.cs
+++ b/src/Typed.Xaml/Internal/Metadata.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using Windows.UI.Xaml;
+
+namespace Typed.Xaml.Internal
+{
+    internal static class Metadata
+    {
+        public static PropertyMetadata CreateFrom<T, TOwner>(PropertyChangedCallback<T, TOwner> callback)
+            where TOwner : DependencyObject
+        {
+            return new PropertyMetadata(default(T), WrapGenericCallback(callback));
+        }
+
+        private static PropertyChangedCallback WrapGenericCallback<T, TOwner>(PropertyChangedCallback<T, TOwner> original)
+            where TOwner : DependencyObject
+        {
+            return (o, args) => original((TOwner)o, PropertyChangedArgs<T>.CreateFrom(args));
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds an `AddOwner<T>` extension method to DependencyProperty that supplants the existing APIs (which require `typeof`).

Potential issues:

- Should generic constraints be enforced? For example, `FooProperty.AddOwner(typeof(string))` seems to work just fine in a WPF application.
 - This also holds true for DependencyProperty.Register and RegisterAttached; should we consider dropping the constraints for the corresponding methods in `Dependency`?

- Another overload should be added that takes a `callback` parameter. This should call into the `metadata` overload, similarly to how `Dependency` does it.