### PR TITLE
Refactor some of the Dependency code into internal methods

### DIFF
--- a/src/Typed.Xaml/Dependency.cs
+++ b/src/Typed.Xaml/Dependency.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Data;
+using Typed.Xaml.Internal;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 
@@ -12,7 +13,7 @@ namespace Typed.Xaml
         public static DependencyProperty Register<T, TOwner>(string name, PropertyChangedCallback<T, TOwner> callback)
             where TOwner : DependencyObject
         {
-            return Register<T, TOwner>(name, CreateMetadata(callback));
+            return Register<T, TOwner>(name, Metadata.Create(callback));
         }
 
         public static DependencyProperty Register<T, TOwner>(string name, PropertyMetadata metadata)
@@ -24,7 +25,7 @@ namespace Typed.Xaml
         public static DependencyProperty RegisterAttached<T, TOwner, TDeclaring>(string name, PropertyChangedCallback<T, TOwner> callback)
             where TOwner : DependencyObject
         {
-            return RegisterAttached<T, TDeclaring>(name, CreateMetadata(callback));
+            return RegisterAttached<T, TDeclaring>(name, Metadata.Create(callback));
         }
 
         public static DependencyProperty RegisterAttached<T, TDeclaring>(string name, PropertyMetadata metadata)

--- a/src/Typed.Xaml/Dependency.cs
+++ b/src/Typed.Xaml/Dependency.cs
@@ -9,12 +9,6 @@ namespace Typed.Xaml
 {
     public static class Dependency
     {
-        private static PropertyMetadata CreateMetadata<T, TOwner>(PropertyChangedCallback<T, TOwner> callback)
-            where TOwner : DependencyObject
-        {
-            return new PropertyMetadata(default(T), WrapGenericCallback(callback));
-        }
-
         public static DependencyProperty Register<T, TOwner>(string name, PropertyChangedCallback<T, TOwner> callback)
             where TOwner : DependencyObject
         {
@@ -36,12 +30,6 @@ namespace Typed.Xaml
         public static DependencyProperty RegisterAttached<T, TDeclaring>(string name, PropertyMetadata metadata)
         {
             return DependencyProperty.RegisterAttached(name, typeof(T), typeof(TDeclaring), metadata);
-        }
-
-        private static PropertyChangedCallback WrapGenericCallback<T, TOwner>(PropertyChangedCallback<T, TOwner> original)
-            where TOwner : DependencyObject
-        {
-            return (o, args) => original((TOwner)o, PropertyChangedArgs<T>.CreateFrom(args));
         }
     }
 }

--- a/src/Typed.Xaml/Dependency.cs
+++ b/src/Typed.Xaml/Dependency.cs
@@ -13,7 +13,7 @@ namespace Typed.Xaml
         public static DependencyProperty Register<T, TOwner>(string name, PropertyChangedCallback<T, TOwner> callback)
             where TOwner : DependencyObject
         {
-            return Register<T, TOwner>(name, Metadata.Create(callback));
+            return Register<T, TOwner>(name, Metadata.CreateFrom(callback));
         }
 
         public static DependencyProperty Register<T, TOwner>(string name, PropertyMetadata metadata)
@@ -25,7 +25,7 @@ namespace Typed.Xaml
         public static DependencyProperty RegisterAttached<T, TOwner, TDeclaring>(string name, PropertyChangedCallback<T, TOwner> callback)
             where TOwner : DependencyObject
         {
-            return RegisterAttached<T, TDeclaring>(name, Metadata.Create(callback));
+            return RegisterAttached<T, TDeclaring>(name, Metadata.CreateFrom(callback));
         }
 
         public static DependencyProperty RegisterAttached<T, TDeclaring>(string name, PropertyMetadata metadata)

--- a/src/Typed.Xaml/Internal/Metadata.cs
+++ b/src/Typed.Xaml/Internal/Metadata.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using Windows.UI.Xaml;
+
+namespace Typed.Xaml.Internal
+{
+    internal static class Metadata
+    {
+        public static PropertyMetadata CreateFrom<T, TOwner>(PropertyChangedCallback<T, TOwner> callback)
+            where TOwner : DependencyObject
+        {
+            return new PropertyMetadata(default(T), WrapGenericCallback(callback));
+        }
+
+        private static PropertyChangedCallback WrapGenericCallback<T, TOwner>(PropertyChangedCallback<T, TOwner> original)
+            where TOwner : DependencyObject
+        {
+            return (o, args) => original((TOwner)o, PropertyChangedArgs<T>.CreateFrom(args));
+        }
+    }
+}


### PR DESCRIPTION
This will enable us to use some of the helper methods from other classes (like `DependencyPropertyExtensions`) when we need it.